### PR TITLE
Bulk load cache data using Zip file

### DIFF
--- a/src/azure-function-example-csharp.csproj
+++ b/src/azure-function-example-csharp.csproj
@@ -11,6 +11,7 @@
 		<PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.3.0" />
 		<PackageReference Include="Microsoft.Azure.WebJobs.Extensions.OpenApi" Version="1.0.0" />
 		<PackageReference Include="System.Data.SQLite.Core" Version="1.0.116" />
+		<PackageReference Include="SharpCompress" Version="0.28.0" />
 	</ItemGroup>
 	<ItemGroup>
 		<None Update="host.json">


### PR DESCRIPTION
Use SharpCompress to uncompress a zip file of stock data to be used in the local SqLite database.

**Note**: *The version of the SharCompress used has a zip-slip vulnerability*